### PR TITLE
Properly generate property schema when DescribeAllParametersInCamelCase is enabled

### DIFF
--- a/src/Swashbuckle.AspNetCore.JsonMultipartFormDataSupport/Integrations/MultiPartJsonOperationFilter.cs
+++ b/src/Swashbuckle.AspNetCore.JsonMultipartFormDataSupport/Integrations/MultiPartJsonOperationFilter.cs
@@ -40,10 +40,7 @@ namespace Swashbuckle.AspNetCore.JsonMultipartFormDataSupport.Integrations {
 		public void Apply(OpenApiOperation operation, OperationFilterContext context) {
 			var descriptors = context.ApiDescription.ActionDescriptor.Parameters.ToList();
 			foreach (var descriptor in descriptors) {
-				// Support for DescribeAllParametersInCamelCase
-				descriptor.Name = _generatorOptions.Value.DescribeAllParametersInCamelCase
-					? descriptor.Name.ToCamelCase()
-					: descriptor.Name;
+				descriptor.Name = GetParameterName(descriptor.Name);
 
 				// Get property with [FromJson]
 				var propertyInfo = GetPropertyInfo(descriptor);
@@ -57,8 +54,10 @@ namespace Swashbuckle.AspNetCore.JsonMultipartFormDataSupport.Integrations {
 
 					var schemaProperties = new Dictionary<string, OpenApiSchema>();
 
+					var propertyInfoName = GetParameterName(propertyInfo.Name);
+
 					foreach (var property in groupedProperties) {
-						if (property.Key == propertyInfo.Name) {
+						if (property.Key == propertyInfoName) {
 							AddEncoding(mediaType, propertyInfo);
 
 							var openApiSchema = GetSchema(context, propertyInfo);
@@ -74,6 +73,14 @@ namespace Swashbuckle.AspNetCore.JsonMultipartFormDataSupport.Integrations {
 					mediaType.Schema.Properties = schemaProperties;
 				}
 			}
+		}
+
+		private string GetParameterName(string name)
+		{
+			// Support for DescribeAllParametersInCamelCase
+			return _generatorOptions.Value.DescribeAllParametersInCamelCase
+				? name.ToCamelCase()
+				: name;
 		}
 
 		/// <summary>


### PR DESCRIPTION
How to reproduce problem:

1. Enable o.DescribeAllParametersInCamelCase() in Demo project
2. Run Demo project
3. Note that "Json" propert is no longer described as "object" type but it is int or string (depending on actual endpoint)

What this fix does:
MultiPartJsonOperationFilter iterates properties and searches for one with same name as property marked with [FromJson] in model. However, when DescribeAllParametersInCamelCase is enabled, incoming property names are in camel case, so they won't match with pascal case model properties. This fix converts model property name to camel case (if needed) and uses this converted name for comparison.