### PR TITLE
Removed newtonsoft and made serialization agnostic via interface

### DIFF
--- a/src/Demo/Demo.csproj
+++ b/src/Demo/Demo.csproj
@@ -9,6 +9,8 @@
     <ItemGroup>
         <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
         <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="6.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.11" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="7.0.0" />
         <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.0.0" />
     </ItemGroup>

--- a/src/Demo/NewtonsoftSerializationProvider.cs
+++ b/src/Demo/NewtonsoftSerializationProvider.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using Swashbuckle.AspNetCore.JsonMultipartFormDataSupport.Integrations;
+
+namespace Demo;
+
+public class NewtonsoftSerializationProvider : IMultipartJsonSerializationProvider
+{
+    private readonly JsonSerializerSettings _serializerSettings;
+    
+    public NewtonsoftSerializationProvider(IOptions<MvcNewtonsoftJsonOptions> options)
+    {
+        _serializerSettings = options.Value.SerializerSettings;
+    }
+
+    public NewtonsoftSerializationProvider()
+    {
+        _serializerSettings = new MvcNewtonsoftJsonOptions().SerializerSettings;
+    }
+    
+    public string Serialize(object value)
+    {
+        return JsonConvert.SerializeObject(value, _serializerSettings);
+    }
+
+    public object Deserialize(ModelBindingContext bindingContext, string valueAsString)
+    {
+        return JsonConvert.DeserializeObject(valueAsString, bindingContext.ModelType, _serializerSettings)!;
+    }
+}

--- a/src/Demo/Program.cs
+++ b/src/Demo/Program.cs
@@ -1,13 +1,14 @@
-using System.Xml;
+using Demo;
 using Demo.Models.Products;
 using FluentValidation;
 using FluentValidation.AspNetCore;
 using MicroElements.Swashbuckle.FluentValidation.AspNetCore;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Swashbuckle.AspNetCore.Filters;
 using Swashbuckle.AspNetCore.JsonMultipartFormDataSupport.Extensions;
-using Swashbuckle.AspNetCore.JsonMultipartFormDataSupport.Integrations;
-using Formatting=Newtonsoft.Json.Formatting;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -30,7 +31,7 @@ builder.Services.AddFluentValidationAutoValidation();
 builder.Services.AddFluentValidationClientsideAdapters();
 builder.Services.AddValidatorsFromAssemblyContaining<ProductValidator>();
 ValidatorOptions.Global.LanguageManager.Enabled = false;
-builder.Services.AddJsonMultipartFormDataSupport(JsonSerializerChoice.Newtonsoft);
+builder.Services.AddJsonMultipartFormDataSupport<NewtonsoftSerializationProvider>();
 builder.Services.AddSwaggerExamplesFromAssemblyOf<ProductExamples>();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();

--- a/src/DemoOld/DemoOld.csproj
+++ b/src/DemoOld/DemoOld.csproj
@@ -12,6 +12,8 @@
   <ItemGroup>
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.11" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="7.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.0.0" />
   </ItemGroup>

--- a/src/DemoOld/NewtonsoftSerializationProvider.cs
+++ b/src/DemoOld/NewtonsoftSerializationProvider.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using Swashbuckle.AspNetCore.JsonMultipartFormDataSupport.Integrations;
+
+namespace DemoOld;
+
+public class NewtonsoftSerializationProvider : IMultipartJsonSerializationProvider
+{
+    private readonly JsonSerializerSettings _serializerSettings;
+    
+    public NewtonsoftSerializationProvider(IOptions<MvcNewtonsoftJsonOptions> options)
+    {
+        _serializerSettings = options.Value.SerializerSettings;
+    }
+
+    public NewtonsoftSerializationProvider()
+    {
+        _serializerSettings = new MvcNewtonsoftJsonOptions().SerializerSettings;
+    }
+    
+    public string Serialize(object value)
+    {
+        return JsonConvert.SerializeObject(value, _serializerSettings);
+    }
+
+    public object Deserialize(ModelBindingContext bindingContext, string valueAsString)
+    {
+        return JsonConvert.DeserializeObject(valueAsString, bindingContext.ModelType, _serializerSettings)!;
+    }
+}

--- a/src/DemoOld/Startup.cs
+++ b/src/DemoOld/Startup.cs
@@ -11,72 +11,72 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Swashbuckle.AspNetCore.Filters;
 using Swashbuckle.AspNetCore.JsonMultipartFormDataSupport.Extensions;
-using Swashbuckle.AspNetCore.JsonMultipartFormDataSupport.Integrations;
 
-namespace DemoOld {
-	public class Startup {
-		public Startup(IConfiguration configuration) {
-			Configuration = configuration;
-		}
+namespace DemoOld;
 
-		public IConfiguration Configuration { get; }
+public class Startup {
+	public Startup(IConfiguration configuration) {
+		Configuration = configuration;
+	}
 
-		// This method gets called by the runtime. Use this method to add services to the container.
-		public void ConfigureServices(IServiceCollection services) {
-			// ===== System.Text.Json =====
-			// services.AddControllers()
-			// 	.AddJsonOptions(options => {
-			// 		options.JsonSerializerOptions.WriteIndented = true;
-			// 		options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
-			// 	});
+	public IConfiguration Configuration { get; }
 
-			// ===== JSON.Net- =====
-			services.AddControllers()
-			        .AddNewtonsoftJson(options => {
-				        options.SerializerSettings.Converters.Add(new StringEnumConverter());
-				        options.SerializerSettings.Formatting = Formatting.Indented;
-			        })
-			        .AddFluentValidation(f => {
-				        f.RegisterValidatorsFromAssemblyContaining<ProductValidator>();
-				        // Important! Without this it won't work automatically
-				        //  vvv
-				        f.ImplicitlyValidateChildProperties = true;
+	// This method gets called by the runtime. Use this method to add services to the container.
+	public void ConfigureServices(IServiceCollection services) {
+		// ===== System.Text.Json =====
+		// services.AddControllers()
+		// 	.AddJsonOptions(options => {
+		// 		options.JsonSerializerOptions.WriteIndented = true;
+		// 		options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+		// 	});
+
+		// ===== JSON.Net- =====
+		services.AddControllers()
+			.AddNewtonsoftJson(options => {
+				options.SerializerSettings.Converters.Add(new StringEnumConverter());
+				options.SerializerSettings.Formatting = Formatting.Indented;
+			})
+			.AddFluentValidation(f => {
+				f.RegisterValidatorsFromAssemblyContaining<ProductValidator>();
+				// Important! Without this it won't work automatically
+				//  vvv
+				f.ImplicitlyValidateChildProperties = true;
 				        
-				        f.LocalizationEnabled = false;
-			        });
-
-			services.AddJsonMultipartFormDataSupport(JsonSerializerChoice.Newtonsoft);
-			services.AddSwaggerExamplesFromAssemblyOf<ProductExamples>();
-			services.AddSwaggerGen(o => {
-				o.SwaggerDoc("v1", new OpenApiInfo {
-					Title = "DemoOld",
-					Version = "v1"
-				});
+				f.LocalizationEnabled = false;
 			});
-			services.AddFluentValidationRulesToSwagger();
+
+		// services.AddSingleton<FormDataJsonBinderProvider<NewtonsoftJsonModelBinder>>(sp => new(new(sp.GetRequiredService<IOptions<MvcNewtonsoftJsonOptions>>())));
+		services.AddJsonMultipartFormDataSupport<NewtonsoftSerializationProvider>();
+		services.AddSwaggerExamplesFromAssemblyOf<ProductExamples>();
+		services.AddSwaggerGen(o => {
+			o.SwaggerDoc("v1", new OpenApiInfo {
+				Title = "DemoOld",
+				Version = "v1"
+			});
+		});
+		services.AddFluentValidationRulesToSwagger();
+	}
+
+	// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+	public void Configure(IApplicationBuilder app, IWebHostEnvironment env) {
+		if (env.IsDevelopment()) {
+			app.UseDeveloperExceptionPage();
 		}
 
-		// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-		public void Configure(IApplicationBuilder app, IWebHostEnvironment env) {
-			if (env.IsDevelopment()) {
-				app.UseDeveloperExceptionPage();
-			}
+		app.UseSwagger();
+		app.UseSwaggerUI(o => {
+			o.SwaggerEndpoint("/swagger/v1/swagger.json", "My API V1");
+			o.RoutePrefix = string.Empty;
+		});
 
-			app.UseSwagger();
-			app.UseSwaggerUI(o => {
-				o.SwaggerEndpoint("/swagger/v1/swagger.json", "My API V1");
-				o.RoutePrefix = string.Empty;
-			});
+		app.UseHttpsRedirection();
 
-			app.UseHttpsRedirection();
+		app.UseRouting();
 
-			app.UseRouting();
+		app.UseAuthorization();
 
-			app.UseAuthorization();
-
-			app.UseEndpoints(endpoints => {
-				endpoints.MapControllers();
-			});
-		}
+		app.UseEndpoints(endpoints => {
+			endpoints.MapControllers();
+		});
 	}
 }

--- a/src/Swashbuckle.AspNetCore.JsonMultipartFormDataSupport/Integrations/FormDataJsonBinderProvider.cs
+++ b/src/Swashbuckle.AspNetCore.JsonMultipartFormDataSupport/Integrations/FormDataJsonBinderProvider.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Reflection;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
-using Microsoft.Extensions.Options;
 using Swashbuckle.AspNetCore.JsonMultipartFormDataSupport.Attributes;
 
 namespace Swashbuckle.AspNetCore.JsonMultipartFormDataSupport.Integrations {
@@ -11,18 +9,13 @@ namespace Swashbuckle.AspNetCore.JsonMultipartFormDataSupport.Integrations {
 	/// Looks for field with <see cref="FromJsonAttribute"/> and use <see cref="JsonModelBinder"/> for binder.
 	/// </summary>
 	public class FormDataJsonBinderProvider : IModelBinderProvider {
-		private readonly IOptions<JsonOptions> _jsonOptions;
-		private readonly IOptions<MvcNewtonsoftJsonOptions> _newtonSoftJsonOptions;
+		readonly JsonModelBinder _jsonModelBinder;
 
-		public FormDataJsonBinderProvider(IOptions<JsonOptions> jsonOptions) {
-			_jsonOptions = jsonOptions;
+		public FormDataJsonBinderProvider(JsonModelBinder jsonModelBinder)
+		{
+			_jsonModelBinder = jsonModelBinder;
 		}
-
-
-		public FormDataJsonBinderProvider(IOptions<MvcNewtonsoftJsonOptions> newtonSoftJsonOptions) {
-			_newtonSoftJsonOptions = newtonSoftJsonOptions;
-		}
-
+		
 		/// <inheritdoc />
 		public IModelBinder GetBinder(ModelBinderProviderContext context) {
 			if (context == null) throw new ArgumentNullException(nameof(context));
@@ -42,13 +35,7 @@ namespace Swashbuckle.AspNetCore.JsonMultipartFormDataSupport.Integrations {
 			// Do not use this provider if this property does not have the From attribute
 			if (propInfo.GetCustomAttribute<FromJsonAttribute>() == null) return null;
 
-			// All criteria met; use the FormDataJsonBinder
-			if (_jsonOptions != null)
-				return new JsonModelBinder(_jsonOptions);
-			else if (_newtonSoftJsonOptions != null)
-				return new JsonModelBinder(_newtonSoftJsonOptions);
-			else
-				return new JsonModelBinder();
+			return _jsonModelBinder;
 		}
 	}
 }

--- a/src/Swashbuckle.AspNetCore.JsonMultipartFormDataSupport/Integrations/IMultipartJsonSerializationProvider.cs
+++ b/src/Swashbuckle.AspNetCore.JsonMultipartFormDataSupport/Integrations/IMultipartJsonSerializationProvider.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace Swashbuckle.AspNetCore.JsonMultipartFormDataSupport.Integrations;
+
+/// <summary>
+/// Serialization provider for <see cref="JsonModelBinder"/> and <see cref="MultiPartJsonOperationFilter"/>.
+/// </summary>
+public interface IMultipartJsonSerializationProvider
+{
+    public object Deserialize(ModelBindingContext bindingContext, string valueAsString);
+    public string Serialize(object value);
+}

--- a/src/Swashbuckle.AspNetCore.JsonMultipartFormDataSupport/Integrations/JsonModelBinder.cs
+++ b/src/Swashbuckle.AspNetCore.JsonMultipartFormDataSupport/Integrations/JsonModelBinder.cs
@@ -1,100 +1,69 @@
 ﻿using System;
 using System.IO;
-using System.Text.Json;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
-using Microsoft.Extensions.Options;
-using Newtonsoft.Json;
-using JsonSerializer = System.Text.Json.JsonSerializer;
 
-namespace Swashbuckle.AspNetCore.JsonMultipartFormDataSupport.Integrations {
-	/// <summary>
-	/// Binds field from JSON string.
-	/// </summary>
-	public class JsonModelBinder : IModelBinder {
-		private readonly IOptions<JsonOptions> _jsonOptions;
-		private readonly IOptions<MvcNewtonsoftJsonOptions> _newtonsoftJsonOptions;
+namespace Swashbuckle.AspNetCore.JsonMultipartFormDataSupport.Integrations;
 
-		public JsonModelBinder() { }
+/// <summary>
+/// Binds field from JSON string.
+/// </summary>
+public class JsonModelBinder : IModelBinder {
+	readonly IMultipartJsonSerializationProvider _serializationProvider;
 
-		public JsonModelBinder(IOptions<JsonOptions> jsonOptions) {
-			_jsonOptions = jsonOptions;
+	public JsonModelBinder(IMultipartJsonSerializationProvider serializationProvider) {
+		_serializationProvider = serializationProvider;
+	}
+		
+	/// <inheritdoc />
+	public async Task BindModelAsync(ModelBindingContext bindingContext) {
+		if (bindingContext == null) {
+			throw new ArgumentNullException(nameof(bindingContext));
 		}
 
-		public JsonModelBinder(IOptions<MvcNewtonsoftJsonOptions> newtonsoftJsonOptions) {
-			_newtonsoftJsonOptions = newtonsoftJsonOptions;
+		string modelBindingKey;
+		if (bindingContext.IsTopLevelObject) {
+			modelBindingKey = bindingContext.BinderModelName;
+		}
+		else {
+			modelBindingKey = bindingContext.ModelName;
 		}
 
-		/// <inheritdoc />
-		public async Task BindModelAsync(ModelBindingContext bindingContext) {
-			if (bindingContext == null) {
-				throw new ArgumentNullException(nameof(bindingContext));
+		// Check the value sent in
+		var valueProviderResult = await this.GetValueProvidedResult(bindingContext);
+		if (valueProviderResult != ValueProviderResult.None) {
+			bindingContext.ModelState.SetModelValue(bindingContext.ModelName, valueProviderResult);
+
+			// Attempt to convert the input value
+			var valueAsString = valueProviderResult.FirstValue;
+
+			try {
+				var result = _serializationProvider.Deserialize(bindingContext, valueAsString);
+
+				bindingContext.Result = ModelBindingResult.Success(result);
 			}
-
-			string modelBindingKey;
-			if (bindingContext.IsTopLevelObject) {
-				modelBindingKey = bindingContext.BinderModelName;
+			catch (Exception e) {
+				bindingContext.ModelState.AddModelError(modelBindingKey ?? string.Empty, e.Message);
 			}
-			else {
-				modelBindingKey = bindingContext.ModelName;
-			}
+		}
+	}
 
-			// Check the value sent in
-			var valueProviderResult = await this.GetValueProvidedResult(bindingContext);
-			if (valueProviderResult != ValueProviderResult.None) {
-				bindingContext.ModelState.SetModelValue(bindingContext.ModelName, valueProviderResult);
-
-				// Attempt to convert the input value
-				var valueAsString = valueProviderResult.FirstValue;
-
-				try {
-					object result;
-					if (_jsonOptions != null) {
-						result = DeserializeUsingSystemSerializer(bindingContext, valueAsString);
-					}
-					else if (_newtonsoftJsonOptions != null) {
-						result = DeserializeUsingJsonNet(bindingContext, valueAsString);
-					}
-					else {
-						result = DeserializeUsingSystemSerializer(bindingContext, valueAsString);
-					}
-
-					bindingContext.Result = ModelBindingResult.Success(result);
-				}
-				catch (Exception e) {
-					bindingContext.ModelState.AddModelError(modelBindingKey ?? string.Empty, e.Message);
-				}
-			}
-        }
-
-		private object DeserializeUsingSystemSerializer(ModelBindingContext bindingContext, string valueAsString) {
-			return JsonSerializer.Deserialize(valueAsString, bindingContext.ModelType,
-				_jsonOptions?.Value?.JsonSerializerOptions ?? new JsonSerializerOptions());
+	private async Task<ValueProviderResult> GetValueProvidedResult(ModelBindingContext bindingContext) {
+		var valueProviderResult = bindingContext.ValueProvider.GetValue(bindingContext.ModelName);
+		if (valueProviderResult != ValueProviderResult.None) {
+			return valueProviderResult;
 		}
 
-		private object DeserializeUsingJsonNet(ModelBindingContext bindingContext, string valueAsString) {
-			return JsonConvert.DeserializeObject(valueAsString, bindingContext.ModelType,
-				_newtonsoftJsonOptions.Value.SerializerSettings);
+		var file = bindingContext.HttpContext.Request.Form.Files.GetFile(bindingContext.ModelName);
+		if (file is null) {
+			return valueProviderResult;
 		}
 
-        private async Task<ValueProviderResult> GetValueProvidedResult(ModelBindingContext bindingContext) {
-            var valueProviderResult = bindingContext.ValueProvider.GetValue(bindingContext.ModelName);
-            if (valueProviderResult != ValueProviderResult.None) {
-                return valueProviderResult;
-            }
+		await using var stream = file.OpenReadStream();
+		using var reader = new StreamReader(stream);
+		var json = await reader.ReadToEndAsync();
+		valueProviderResult = new ValueProviderResult(json);
 
-            var file = bindingContext.HttpContext.Request.Form.Files.GetFile(bindingContext.ModelName);
-            if (file is null) {
-                return valueProviderResult;
-            }
-
-            await using var stream = file.OpenReadStream();
-            using var reader = new StreamReader(stream);
-            var json = await reader.ReadToEndAsync();
-            valueProviderResult = new ValueProviderResult(json);
-
-            return valueProviderResult;
-        }
-    }
+		return valueProviderResult;
+	}
 }

--- a/src/Swashbuckle.AspNetCore.JsonMultipartFormDataSupport/Integrations/JsonMultipartFormDataOptions.cs
+++ b/src/Swashbuckle.AspNetCore.JsonMultipartFormDataSupport/Integrations/JsonMultipartFormDataOptions.cs
@@ -1,5 +1,0 @@
-﻿namespace Swashbuckle.AspNetCore.JsonMultipartFormDataSupport.Integrations {
-	internal static class JsonMultipartFormDataOptions {
-		internal static JsonSerializerChoice JsonSerializerChoice = JsonSerializerChoice.SystemText;
-	}
-}

--- a/src/Swashbuckle.AspNetCore.JsonMultipartFormDataSupport/Integrations/JsonSerializerChoice.cs
+++ b/src/Swashbuckle.AspNetCore.JsonMultipartFormDataSupport/Integrations/JsonSerializerChoice.cs
@@ -1,6 +1,0 @@
-﻿namespace Swashbuckle.AspNetCore.JsonMultipartFormDataSupport.Integrations {
-	public enum JsonSerializerChoice {
-		SystemText,
-		Newtonsoft
-	}
-}

--- a/src/Swashbuckle.AspNetCore.JsonMultipartFormDataSupport/Swashbuckle.AspNetCore.JsonMultipartFormDataSupport.csproj
+++ b/src/Swashbuckle.AspNetCore.JsonMultipartFormDataSupport/Swashbuckle.AspNetCore.JsonMultipartFormDataSupport.csproj
@@ -18,7 +18,6 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.11" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="7.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="8.0.2" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="7.0.0" />

--- a/src/tests/UnitTests/FormDataJsonBinderProviderTests.cs
+++ b/src/tests/UnitTests/FormDataJsonBinderProviderTests.cs
@@ -12,7 +12,7 @@ public class FormDataJsonBinderProviderTests {
 	public void GetBinder_ContextIsNull_ShouldThrowException() {
 		// Arrange
 		var options = Substitute.For<IOptions<JsonOptions>>();
-		var sut = new FormDataJsonBinderProvider(options);
+		var sut = new FormDataJsonBinderProvider(new(new JsonSerializationProvider(options)));
 		// Act
 		var action = () => sut.GetBinder(null!);
 		// Assert
@@ -26,7 +26,7 @@ public class FormDataJsonBinderProviderTests {
 	public void GetBinder_SimpleType_ShouldReturnNull(Type type) {
 		// Arrange
 		var options = Substitute.For<IOptions<JsonOptions>>();
-		var sut = new FormDataJsonBinderProvider(options);
+		var sut = new FormDataJsonBinderProvider(new(new JsonSerializationProvider(options)));
 		var context = new TestModelBinderProviderContext(new TestModelMetadata(ModelMetadataIdentity.ForType(type)));
 		// Act
 		var result = sut.GetBinder(context);
@@ -38,7 +38,7 @@ public class FormDataJsonBinderProviderTests {
 	public void GetBinder_NotProperty_ShouldReturnNull() {
 		// Arrange
 		var options = Substitute.For<IOptions<JsonOptions>>();
-		var sut = new FormDataJsonBinderProvider(options);
+		var sut = new FormDataJsonBinderProvider(new(new JsonSerializationProvider(options)));
 		var context =
 			new TestModelBinderProviderContext(
 				new TestModelMetadata(ModelMetadataIdentity.ForType(typeof(TestTypeNoProperty))));
@@ -52,7 +52,7 @@ public class FormDataJsonBinderProviderTests {
 	public void GetBinder_IFormFileProperty_ShouldReturnNull() {
 		// Arrange
 		var options = Substitute.For<IOptions<JsonOptions>>();
-		var sut = new FormDataJsonBinderProvider(options);
+		var sut = new FormDataJsonBinderProvider(new(new JsonSerializationProvider(options)));
 		var context =
 			TestModelBinderProviderContext.ForProperty(typeof(TestTypePropertyIFromFile), nameof(TestTypePropertyIFromFile.Test));
 		// Act
@@ -65,7 +65,7 @@ public class FormDataJsonBinderProviderTests {
 	public void GetBinder_PropertyWithoutFromJsonAttribute_ShouldReturnNull() {
 		// Arrange
 		var options = Substitute.For<IOptions<JsonOptions>>();
-		var sut = new FormDataJsonBinderProvider(options);
+		var sut = new FormDataJsonBinderProvider(new(new JsonSerializationProvider(options)));
 		var context =
 			TestModelBinderProviderContext.ForProperty(typeof(TestTypeNoAttribute), nameof(TestTypeNoAttribute.Test));
 		// Act
@@ -78,7 +78,7 @@ public class FormDataJsonBinderProviderTests {
 	public void GetBinder_ShouldReturnJsonBinder() {
 		// Arrange
 		var options = Substitute.For<IOptions<JsonOptions>>();
-		var sut = new FormDataJsonBinderProvider(options);
+		var sut = new FormDataJsonBinderProvider(new(new JsonSerializationProvider(options)));
 		var context = TestModelBinderProviderContext.ForProperty(typeof(TestTypeContainer), nameof(TestTypeContainer.Test));
 		// Act
 		var result = sut.GetBinder(context);

--- a/src/tests/UnitTests/JsonModelBinderTests.cs
+++ b/src/tests/UnitTests/JsonModelBinderTests.cs
@@ -1,8 +1,8 @@
-﻿using System.Text.Json;
-using Microsoft.AspNetCore.Mvc.ModelBinding;
+﻿using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.Primitives;
 using Swashbuckle.AspNetCore.JsonMultipartFormDataSupport.Integrations;
 using UnitTests.TestData.Types;
+using JsonSerializer = System.Text.Json.JsonSerializer;
 
 namespace UnitTests;
 
@@ -10,7 +10,7 @@ public class JsonModelBinderTests {
 	[Test]
 	public void BindModelAsync_NullContext_ShouldReturnNull() {
 		// Arrange
-		var sut = new JsonModelBinder();
+		var sut = new JsonModelBinder(new NewtonsoftSerializationProvider());
 		// Act
 		var action = async () => await sut.BindModelAsync(null!);
 		// Assert
@@ -20,7 +20,7 @@ public class JsonModelBinderTests {
 	[Test]
 	public async Task BindModelAsync_ShouldBindData() {
 		// Arrange
-		var sut = new JsonModelBinder();
+		var sut = new JsonModelBinder(new NewtonsoftSerializationProvider());
 		var testType = new TestType {
 			Id = 1,
 			Text = Guid.NewGuid().ToString()

--- a/src/tests/UnitTests/JsonSerializationProvider.cs
+++ b/src/tests/UnitTests/JsonSerializationProvider.cs
@@ -1,0 +1,32 @@
+﻿using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.Options;
+using Swashbuckle.AspNetCore.JsonMultipartFormDataSupport.Integrations;
+
+namespace UnitTests;
+
+public class JsonSerializationProvider : IMultipartJsonSerializationProvider
+{
+    private readonly JsonSerializerOptions _serializerOptions;
+    
+    public JsonSerializationProvider(IOptions<JsonOptions> options)
+    {
+        _serializerOptions = options.Value?.JsonSerializerOptions ?? new JsonOptions().JsonSerializerOptions;
+    }
+
+    public JsonSerializationProvider()
+    {
+        _serializerOptions = new JsonOptions().JsonSerializerOptions;
+    }
+    
+    public string Serialize(object value)
+    {
+        return JsonSerializer.Serialize(value, _serializerOptions);
+    }
+
+    public object Deserialize(ModelBindingContext bindingContext, string valueAsString)
+    {
+        return JsonSerializer.Deserialize(valueAsString, bindingContext.ModelType, _serializerOptions)!;
+    }
+}

--- a/src/tests/UnitTests/NewtonsoftSerializationProvider.cs
+++ b/src/tests/UnitTests/NewtonsoftSerializationProvider.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using Swashbuckle.AspNetCore.JsonMultipartFormDataSupport.Integrations;
+
+namespace UnitTests;
+
+public class NewtonsoftSerializationProvider : IMultipartJsonSerializationProvider
+{
+    private readonly JsonSerializerSettings _serializerSettings;
+    
+    public NewtonsoftSerializationProvider(IOptions<MvcNewtonsoftJsonOptions> options)
+    {
+        _serializerSettings = options.Value.SerializerSettings;
+    }
+
+    public NewtonsoftSerializationProvider()
+    {
+        _serializerSettings = new MvcNewtonsoftJsonOptions().SerializerSettings;
+    }
+    
+    public string Serialize(object value)
+    {
+        return JsonConvert.SerializeObject(value, _serializerSettings);
+    }
+
+    public object Deserialize(ModelBindingContext bindingContext, string valueAsString)
+    {
+        return JsonConvert.DeserializeObject(valueAsString, bindingContext.ModelType, _serializerSettings)!;
+    }
+}

--- a/src/tests/UnitTests/UnitTests.csproj
+++ b/src/tests/UnitTests/UnitTests.csproj
@@ -9,6 +9,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.11" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
         <PackageReference Include="NSubstitute" Version="4.4.0" />
         <PackageReference Include="NUnit" Version="3.13.2" />


### PR DESCRIPTION
I had need/use of the nuget, but I like to avoid having references to Newtonsoft unless I'm explicitly using it, so I fixed up a version that doesn't need the dependency and can support theoretically any serializer. 